### PR TITLE
feat(VStack): VStack 컴포넌트 구현

### DIFF
--- a/src/components/VStack/VStack.stories.tsx
+++ b/src/components/VStack/VStack.stories.tsx
@@ -1,0 +1,256 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { css } from "../../../styled-system/css";
+import { grid } from "../../../styled-system/patterns";
+import { VStack } from "./VStack";
+
+/** 데모용 VStack 컨테이너 스타일 */
+const containerStyle = css({
+  width: "200px",
+  height: "250px",
+  border: "1px dashed",
+  borderColor: "border.neutral",
+  borderRadius: "8",
+  bg: "bg.neutral/50",
+});
+
+/** 데모용 자식 요소 스타일 객체 */
+const itemStyleProps = {
+  px: "12",
+  py: "8",
+  bg: "bg.brand",
+  color: "fg.onColor",
+  borderRadius: "4",
+  fontWeight: "medium",
+  fontSize: "14",
+} as const;
+
+/** 데모용 자식 요소 스타일 */
+const itemStyle = css(itemStyleProps);
+
+export default {
+  component: VStack,
+  parameters: {
+    layout: "centered",
+  },
+  argTypes: {
+    as: {
+      control: "select",
+      options: [
+        "div",
+        "section",
+        "article",
+        "header",
+        "footer",
+        "main",
+        "nav",
+        "aside",
+        "span",
+      ],
+      description: "렌더링할 HTML 요소",
+    },
+    justify: {
+      control: "select",
+      options: ["start", "center", "end", "between", "around", "evenly"],
+      description: "주축 정렬 방식",
+    },
+    align: {
+      control: "select",
+      options: ["start", "center", "end", "stretch", "baseline"],
+      description: "교차축 정렬 방식",
+    },
+    wrap: {
+      control: "select",
+      options: ["nowrap", "wrap", "wrapReverse"],
+      description: "줄바꿈 방식",
+    },
+    gap: {
+      control: "select",
+      options: [0, 4, 8, 12, 16, 20, 24, 32, 40, 48, 56, 64],
+      description: "아이템 간 간격 (spacing 토큰)",
+    },
+    inline: {
+      control: "boolean",
+      description: "inline-flex로 렌더링",
+    },
+  },
+  args: {
+    justify: "start",
+    align: "stretch",
+    wrap: "nowrap",
+    gap: 8,
+    inline: false,
+    className: containerStyle,
+    children: (
+      <>
+        <span className={itemStyle}>A</span>
+        <span className={itemStyle}>B</span>
+        <span className={itemStyle}>C</span>
+      </>
+    ),
+  },
+} satisfies Meta<typeof VStack>;
+
+type Story = StoryObj<typeof VStack>;
+
+/** 기본 사용법 */
+export const Basic: Story = {};
+
+/** 주축(main axis) 정렬 방식을 설정합니다. VStack에서는 세로 방향이 주축입니다. */
+export const Justify: Story = {
+  render: (args) => (
+    <div className={grid({ gridTemplateColumns: "repeat(3, 1fr)", gap: "24" })}>
+      <div>
+        <h4 className={css({ mb: "8", fontWeight: "semibold" })}>start</h4>
+        <VStack {...args} justify="start" />
+      </div>
+      <div>
+        <h4 className={css({ mb: "8", fontWeight: "semibold" })}>center</h4>
+        <VStack {...args} justify="center" />
+      </div>
+      <div>
+        <h4 className={css({ mb: "8", fontWeight: "semibold" })}>end</h4>
+        <VStack {...args} justify="end" />
+      </div>
+      <div>
+        <h4 className={css({ mb: "8", fontWeight: "semibold" })}>between</h4>
+        <VStack {...args} justify="between" />
+      </div>
+      <div>
+        <h4 className={css({ mb: "8", fontWeight: "semibold" })}>around</h4>
+        <VStack {...args} justify="around" />
+      </div>
+      <div>
+        <h4 className={css({ mb: "8", fontWeight: "semibold" })}>evenly</h4>
+        <VStack {...args} justify="evenly" />
+      </div>
+    </div>
+  ),
+  argTypes: {
+    justify: { control: false },
+  },
+};
+
+/** 교차축(cross axis) 정렬 방식을 설정합니다. VStack에서는 가로 방향이 교차축입니다. */
+export const Align: Story = {
+  render: (args) => (
+    <div className={grid({ gridTemplateColumns: "repeat(3, 1fr)", gap: "24" })}>
+      <div>
+        <h4 className={css({ mb: "8", fontWeight: "semibold" })}>start</h4>
+        <VStack {...args} align="start" />
+      </div>
+      <div>
+        <h4 className={css({ mb: "8", fontWeight: "semibold" })}>center</h4>
+        <VStack {...args} align="center" />
+      </div>
+      <div>
+        <h4 className={css({ mb: "8", fontWeight: "semibold" })}>end</h4>
+        <VStack {...args} align="end" />
+      </div>
+      <div>
+        <h4 className={css({ mb: "8", fontWeight: "semibold" })}>stretch</h4>
+        <VStack {...args} align="stretch">
+          <span className={itemStyle}>A</span>
+          <span className={itemStyle}>B</span>
+          <span className={itemStyle}>C</span>
+        </VStack>
+      </div>
+      <div>
+        <h4 className={css({ mb: "8", fontWeight: "semibold" })}>baseline</h4>
+        <VStack {...args} align="baseline">
+          <span className={css({ ...itemStyleProps, fontSize: "12" })}>
+            Small
+          </span>
+          <span className={css({ ...itemStyleProps, fontSize: "20" })}>
+            Large
+          </span>
+          <span className={css({ ...itemStyleProps, fontSize: "16" })}>
+            Medium
+          </span>
+        </VStack>
+      </div>
+    </div>
+  ),
+  argTypes: {
+    align: { control: false },
+  },
+};
+
+/** 아이템 간 간격을 설정합니다. spacing 토큰을 사용합니다. */
+export const Gap: Story = {
+  render: (args) => (
+    <div className={grid({ gridTemplateColumns: "repeat(3, 1fr)", gap: "24" })}>
+      {([0, 4, 8, 16, 24, 32] as const).map((gapValue) => (
+        <div key={gapValue}>
+          <h4 className={css({ mb: "8", fontWeight: "semibold" })}>
+            gap: {gapValue}
+          </h4>
+          <VStack {...args} gap={gapValue} />
+        </div>
+      ))}
+    </div>
+  ),
+  argTypes: {
+    gap: { control: false },
+  },
+  args: {
+    className: css({
+      width: "fit-content",
+      border: "1px dashed",
+      borderColor: "border.neutral",
+      borderRadius: "8",
+      bg: "bg.neutral/50",
+      p: "8",
+    }),
+  },
+};
+
+/** `inline` prop으로 inline-flex와 flex를 전환합니다. */
+export const Inline: Story = {
+  render: (args) => (
+    <div className={grid({ gridTemplateColumns: "repeat(2, 1fr)", gap: "24" })}>
+      <div>
+        <h4 className={css({ mb: "8", fontWeight: "semibold" })}>
+          inline=false (block)
+        </h4>
+        <div
+          className={css({
+            border: "1px solid",
+            borderColor: "border.neutral",
+            p: "8",
+          })}
+        >
+          <VStack {...args} inline={false}>
+            <span className={itemStyle}>A</span>
+            <span className={itemStyle}>B</span>
+          </VStack>
+          <span>다음 텍스트</span>
+        </div>
+      </div>
+      <div>
+        <h4 className={css({ mb: "8", fontWeight: "semibold" })}>
+          inline=true
+        </h4>
+        <div
+          className={css({
+            border: "1px solid",
+            borderColor: "border.neutral",
+            p: "8",
+          })}
+        >
+          <VStack {...args} inline={true}>
+            <span className={itemStyle}>A</span>
+            <span className={itemStyle}>B</span>
+          </VStack>
+          <span>다음 텍스트</span>
+        </div>
+      </div>
+    </div>
+  ),
+  argTypes: {
+    inline: { control: false },
+  },
+  args: {
+    className: undefined,
+    gap: 8,
+  },
+};

--- a/src/components/VStack/VStack.test.tsx
+++ b/src/components/VStack/VStack.test.tsx
@@ -1,0 +1,129 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, test } from "vitest";
+import { VStack } from "./VStack";
+
+describe("렌더링", () => {
+  test("자식 요소들이 올바르게 렌더링됨", () => {
+    render(
+      <VStack>
+        <span>첫번째</span>
+        <span>두번째</span>
+      </VStack>,
+    );
+
+    expect(screen.getByText("첫번째")).toBeInTheDocument();
+    expect(screen.getByText("두번째")).toBeInTheDocument();
+  });
+
+  test("direction이 column으로 렌더링됨", () => {
+    render(<VStack>내용</VStack>);
+
+    expect(screen.getByText("내용")).toHaveClass("flex-d_column");
+  });
+});
+
+describe("as 속성", () => {
+  test("기본값으로 div 태그로 렌더링됨", () => {
+    const { container } = render(<VStack>내용</VStack>);
+
+    expect(container.querySelector("div")).toBeInTheDocument();
+  });
+
+  test.each([
+    { as: "section", tagName: "SECTION" },
+    { as: "nav", tagName: "NAV" },
+    { as: "article", tagName: "ARTICLE" },
+    { as: "header", tagName: "HEADER" },
+    { as: "footer", tagName: "FOOTER" },
+    { as: "main", tagName: "MAIN" },
+    { as: "aside", tagName: "ASIDE" },
+    { as: "span", tagName: "SPAN" },
+  ] as const)("as=$as일 때 $tagName 태그로 렌더링됨", ({ as, tagName }) => {
+    const { container } = render(<VStack as={as}>내용</VStack>);
+
+    expect(container.firstChild).toHaveProperty("tagName", tagName);
+  });
+});
+
+describe("inline 속성", () => {
+  test("inline={false}일 때 flex로 렌더링됨", () => {
+    render(<VStack inline={false}>내용</VStack>);
+
+    expect(screen.getByText("내용")).toHaveClass("d_flex");
+  });
+
+  test("inline={true}일 때 inline-flex로 렌더링됨", () => {
+    render(<VStack inline>내용</VStack>);
+
+    expect(screen.getByText("내용")).toHaveClass("d_inline-flex");
+  });
+});
+
+describe("wrap 속성", () => {
+  test.each([
+    { wrap: "nowrap", className: "flex-wrap_nowrap" },
+    { wrap: "wrap", className: "flex-wrap_wrap" },
+    { wrap: "wrapReverse", className: "flex-wrap_wrap-reverse" },
+  ] as const)("wrap=$wrap일 때 $className 클래스가 적용됨", ({
+    wrap,
+    className,
+  }) => {
+    render(<VStack wrap={wrap}>내용</VStack>);
+
+    expect(screen.getByText("내용")).toHaveClass(className);
+  });
+});
+
+describe("align 속성", () => {
+  test.each([
+    { align: "start", className: "ai_flex-start" },
+    { align: "center", className: "ai_center" },
+    { align: "end", className: "ai_flex-end" },
+    { align: "stretch", className: "ai_stretch" },
+    { align: "baseline", className: "ai_baseline" },
+  ] as const)("align=$align일 때 $className 클래스가 적용됨", ({
+    align,
+    className,
+  }) => {
+    render(<VStack align={align}>내용</VStack>);
+
+    expect(screen.getByText("내용")).toHaveClass(className);
+  });
+});
+
+describe("justify 속성", () => {
+  test.each([
+    { justify: "start", className: "jc_flex-start" },
+    { justify: "center", className: "jc_center" },
+    { justify: "end", className: "jc_flex-end" },
+    { justify: "between", className: "jc_space-between" },
+    { justify: "around", className: "jc_space-around" },
+    { justify: "evenly", className: "jc_space-evenly" },
+  ] as const)("justify=$justify일 때 $className 클래스가 적용됨", ({
+    justify,
+    className,
+  }) => {
+    render(<VStack justify={justify}>내용</VStack>);
+
+    expect(screen.getByText("내용")).toHaveClass(className);
+  });
+});
+
+describe("gap 속성", () => {
+  test("gap이 지정되면 gap 스타일이 적용됨", () => {
+    render(<VStack gap={8}>내용</VStack>);
+
+    expect(screen.getByText("내용")).toHaveClass("gap_8");
+  });
+});
+
+describe("className 속성", () => {
+  test("외부 className이 병합되어 적용됨", () => {
+    render(<VStack className="custom-class">내용</VStack>);
+
+    const element = screen.getByText("내용");
+    expect(element).toHaveClass("custom-class");
+    expect(element).toHaveClass("d_flex");
+    expect(element).toHaveClass("flex-d_column");
+  });
+});

--- a/src/components/VStack/VStack.tsx
+++ b/src/components/VStack/VStack.tsx
@@ -1,0 +1,14 @@
+import type { ReactNode } from "react";
+import { Flex, type FlexProps } from "../Flex/Flex";
+
+export interface VStackProps extends Omit<FlexProps, "direction"> {
+  children: ReactNode;
+}
+
+export const VStack = ({ children, ...props }: VStackProps) => {
+  return (
+    <Flex direction="column" {...props}>
+      {children}
+    </Flex>
+  );
+};


### PR DESCRIPTION
## 개요
Flex 컴포넌트를 기반으로 VStack (Vertical Stack) 컴포넌트를 구현했습니다.

## 변경 사항
- `src/components/VStack/VStack.tsx`: Flex 래핑, `direction="column"` 고정
- `src/components/VStack/VStack.stories.tsx`: Basic, Justify, Align, Gap, Inline 스토리
- `src/components/VStack/VStack.test.tsx`: 29개 테스트

## 설계 결정
- Flex의 단순 래퍼로 구현하여 기존 API를 그대로 유지
- `direction` prop만 제외하고 나머지 FlexProps 모두 지원
- 새로운 API 학습 비용 최소화

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced VStack component for creating vertical layouts with configurable alignment, spacing, and wrapping options.
  * Supports rendering as different HTML elements and both block/inline display modes.

* **Documentation**
  * Added comprehensive Storybook stories demonstrating VStack usage across various configurations and alignment scenarios.

* **Tests**
  * Added test suite verifying component rendering, prop behavior, and class composition.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->