### PR TITLE
feat(HStack): HStack 컴포넌트 구현

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -8,7 +8,7 @@ const config: StorybookConfig = {
     "@storybook/addon-themes",
     "@storybook/addon-designs",
     "@storybook/addon-docs",
-    "@storybook/addon-vitest"
+    "@storybook/addon-vitest",
   ],
   framework: {
     name: "@storybook/react-vite",

--- a/src/components/HStack/HStack.stories.tsx
+++ b/src/components/HStack/HStack.stories.tsx
@@ -1,0 +1,301 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { css } from "../../../styled-system/css";
+import { grid, vstack } from "../../../styled-system/patterns";
+import { HStack } from "./HStack";
+
+/** 데모용 HStack 컨테이너 스타일 */
+const containerStyle = css({
+  width: "400px",
+  height: "100px",
+  border: "1px dashed",
+  borderColor: "border.neutral",
+  borderRadius: "8",
+  bg: "bg.neutral/50",
+});
+
+/** 데모용 자식 요소 스타일 객체 */
+const itemStyleProps = {
+  px: "12",
+  py: "8",
+  bg: "bg.brand",
+  color: "fg.onColor",
+  borderRadius: "4",
+  fontWeight: "medium",
+  fontSize: "14",
+} as const;
+
+/** 데모용 자식 요소 스타일 */
+const itemStyle = css(itemStyleProps);
+
+export default {
+  component: HStack,
+  parameters: {
+    layout: "centered",
+  },
+  argTypes: {
+    as: {
+      control: "select",
+      options: [
+        "div",
+        "section",
+        "article",
+        "header",
+        "footer",
+        "main",
+        "nav",
+        "aside",
+        "span",
+      ],
+      description: "렌더링할 HTML 요소",
+    },
+    justify: {
+      control: "select",
+      options: ["start", "center", "end", "between", "around", "evenly"],
+      description: "주축 정렬 방식",
+    },
+    align: {
+      control: "select",
+      options: ["start", "center", "end", "stretch", "baseline"],
+      description: "교차축 정렬 방식",
+    },
+    wrap: {
+      control: "select",
+      options: ["nowrap", "wrap", "wrapReverse"],
+      description: "줄바꿈 방식",
+    },
+    gap: {
+      control: "select",
+      options: [0, 4, 8, 12, 16, 20, 24, 32, 40, 48, 56, 64],
+      description: "아이템 간 간격 (spacing 토큰)",
+    },
+    inline: {
+      control: "boolean",
+      description: "inline-flex로 렌더링",
+    },
+  },
+  args: {
+    justify: "start",
+    align: "stretch",
+    wrap: "nowrap",
+    gap: 8,
+    inline: false,
+    className: containerStyle,
+    children: (
+      <>
+        <span className={itemStyle}>A</span>
+        <span className={itemStyle}>B</span>
+        <span className={itemStyle}>C</span>
+      </>
+    ),
+  },
+} satisfies Meta<typeof HStack>;
+
+type Story = StoryObj<typeof HStack>;
+
+/** 기본 사용법 */
+export const Basic: Story = {};
+
+/** 주축(main axis) 정렬 방식을 설정합니다. HStack에서는 가로 방향이 주축입니다. */
+export const Justify: Story = {
+  render: (args) => (
+    <div className={vstack({ gap: "16" })}>
+      <div>
+        <h4 className={css({ mb: "8", fontWeight: "semibold" })}>start</h4>
+        <HStack {...args} justify="start" />
+      </div>
+      <div>
+        <h4 className={css({ mb: "8", fontWeight: "semibold" })}>center</h4>
+        <HStack {...args} justify="center" />
+      </div>
+      <div>
+        <h4 className={css({ mb: "8", fontWeight: "semibold" })}>end</h4>
+        <HStack {...args} justify="end" />
+      </div>
+      <div>
+        <h4 className={css({ mb: "8", fontWeight: "semibold" })}>between</h4>
+        <HStack {...args} justify="between" />
+      </div>
+      <div>
+        <h4 className={css({ mb: "8", fontWeight: "semibold" })}>around</h4>
+        <HStack {...args} justify="around" />
+      </div>
+      <div>
+        <h4 className={css({ mb: "8", fontWeight: "semibold" })}>evenly</h4>
+        <HStack {...args} justify="evenly" />
+      </div>
+    </div>
+  ),
+  argTypes: {
+    justify: { control: false },
+  },
+};
+
+/** 교차축(cross axis) 정렬 방식을 설정합니다. HStack에서는 세로 방향이 교차축입니다. */
+export const Align: Story = {
+  render: (args) => (
+    <div className={vstack({ gap: "16" })}>
+      <div>
+        <h4 className={css({ mb: "8", fontWeight: "semibold" })}>start</h4>
+        <HStack {...args} align="start" />
+      </div>
+      <div>
+        <h4 className={css({ mb: "8", fontWeight: "semibold" })}>center</h4>
+        <HStack {...args} align="center" />
+      </div>
+      <div>
+        <h4 className={css({ mb: "8", fontWeight: "semibold" })}>end</h4>
+        <HStack {...args} align="end" />
+      </div>
+      <div>
+        <h4 className={css({ mb: "8", fontWeight: "semibold" })}>stretch</h4>
+        <HStack {...args} align="stretch">
+          <span className={itemStyle}>A</span>
+          <span className={itemStyle}>B</span>
+          <span className={itemStyle}>C</span>
+        </HStack>
+      </div>
+      <div>
+        <h4 className={css({ mb: "8", fontWeight: "semibold" })}>baseline</h4>
+        <HStack {...args} align="baseline">
+          <span className={css({ ...itemStyleProps, fontSize: "12" })}>
+            Small
+          </span>
+          <span className={css({ ...itemStyleProps, fontSize: "20" })}>
+            Large
+          </span>
+          <span className={css({ ...itemStyleProps, fontSize: "16" })}>
+            Medium
+          </span>
+        </HStack>
+      </div>
+    </div>
+  ),
+  argTypes: {
+    align: { control: false },
+  },
+};
+
+/** 아이템 간 간격을 설정합니다. spacing 토큰을 사용합니다. */
+export const Gap: Story = {
+  render: (args) => (
+    <div className={vstack({ gap: "16" })}>
+      {([0, 4, 8, 16, 24, 32] as const).map((gapValue) => (
+        <div key={gapValue}>
+          <h4 className={css({ mb: "8", fontWeight: "semibold" })}>
+            gap: {gapValue}
+          </h4>
+          <HStack {...args} gap={gapValue} />
+        </div>
+      ))}
+    </div>
+  ),
+  argTypes: {
+    gap: { control: false },
+  },
+  args: {
+    className: css({
+      width: "fit-content",
+      border: "1px dashed",
+      borderColor: "border.neutral",
+      borderRadius: "8",
+      bg: "bg.neutral/50",
+      p: "8",
+    }),
+  },
+};
+
+/** 아이템이 컨테이너를 넘칠 때 줄바꿈 방식을 설정합니다. */
+export const Wrap: Story = {
+  render: (args) => (
+    <div className={vstack({ gap: "24" })}>
+      <div>
+        <h4 className={css({ mb: "8", fontWeight: "semibold" })}>
+          nowrap (기본값)
+        </h4>
+        <HStack {...args} wrap="nowrap" />
+      </div>
+      <div>
+        <h4 className={css({ mb: "8", fontWeight: "semibold" })}>wrap</h4>
+        <HStack {...args} wrap="wrap" />
+      </div>
+      <div>
+        <h4 className={css({ mb: "8", fontWeight: "semibold" })}>
+          wrapReverse
+        </h4>
+        <HStack {...args} wrap="wrapReverse" />
+      </div>
+    </div>
+  ),
+  argTypes: {
+    wrap: { control: false },
+  },
+  args: {
+    className: css({
+      width: "200px",
+      border: "1px dashed",
+      borderColor: "border.neutral",
+      borderRadius: "8",
+      bg: "bg.neutral/50",
+      p: "8",
+    }),
+    children: (
+      <>
+        <span className={itemStyle}>Item 1</span>
+        <span className={itemStyle}>Item 2</span>
+        <span className={itemStyle}>Item 3</span>
+        <span className={itemStyle}>Item 4</span>
+      </>
+    ),
+  },
+};
+
+/** `inline` prop으로 inline-flex와 flex를 전환합니다. */
+export const Inline: Story = {
+  render: (args) => (
+    <div className={grid({ gridTemplateColumns: "repeat(2, 1fr)", gap: "24" })}>
+      <div>
+        <h4 className={css({ mb: "8", fontWeight: "semibold" })}>
+          inline=false (block)
+        </h4>
+        <div
+          className={css({
+            border: "1px solid",
+            borderColor: "border.neutral",
+            p: "8",
+          })}
+        >
+          <HStack {...args} inline={false}>
+            <span className={itemStyle}>A</span>
+            <span className={itemStyle}>B</span>
+          </HStack>
+          <span>다음 텍스트</span>
+        </div>
+      </div>
+      <div>
+        <h4 className={css({ mb: "8", fontWeight: "semibold" })}>
+          inline=true
+        </h4>
+        <div
+          className={css({
+            border: "1px solid",
+            borderColor: "border.neutral",
+            p: "8",
+          })}
+        >
+          <HStack {...args} inline={true}>
+            <span className={itemStyle}>A</span>
+            <span className={itemStyle}>B</span>
+          </HStack>
+          <span>다음 텍스트</span>
+        </div>
+      </div>
+    </div>
+  ),
+  argTypes: {
+    inline: { control: false },
+  },
+  args: {
+    className: undefined,
+    gap: 8,
+  },
+};

--- a/src/components/HStack/HStack.test.tsx
+++ b/src/components/HStack/HStack.test.tsx
@@ -1,0 +1,129 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, test } from "vitest";
+import { HStack } from "./HStack";
+
+describe("렌더링", () => {
+  test("자식 요소들이 올바르게 렌더링됨", () => {
+    render(
+      <HStack>
+        <span>첫번째</span>
+        <span>두번째</span>
+      </HStack>,
+    );
+
+    expect(screen.getByText("첫번째")).toBeInTheDocument();
+    expect(screen.getByText("두번째")).toBeInTheDocument();
+  });
+
+  test("direction이 row로 렌더링됨", () => {
+    render(<HStack>내용</HStack>);
+
+    expect(screen.getByText("내용")).toHaveClass("flex-d_row");
+  });
+});
+
+describe("as 속성", () => {
+  test("기본값으로 div 태그로 렌더링됨", () => {
+    const { container } = render(<HStack>내용</HStack>);
+
+    expect(container.querySelector("div")).toBeInTheDocument();
+  });
+
+  test.each([
+    { as: "section", tagName: "SECTION" },
+    { as: "nav", tagName: "NAV" },
+    { as: "article", tagName: "ARTICLE" },
+    { as: "header", tagName: "HEADER" },
+    { as: "footer", tagName: "FOOTER" },
+    { as: "main", tagName: "MAIN" },
+    { as: "aside", tagName: "ASIDE" },
+    { as: "span", tagName: "SPAN" },
+  ] as const)("as=$as일 때 $tagName 태그로 렌더링됨", ({ as, tagName }) => {
+    const { container } = render(<HStack as={as}>내용</HStack>);
+
+    expect(container.firstChild).toHaveProperty("tagName", tagName);
+  });
+});
+
+describe("inline 속성", () => {
+  test("inline={false}일 때 flex로 렌더링됨", () => {
+    render(<HStack inline={false}>내용</HStack>);
+
+    expect(screen.getByText("내용")).toHaveClass("d_flex");
+  });
+
+  test("inline={true}일 때 inline-flex로 렌더링됨", () => {
+    render(<HStack inline>내용</HStack>);
+
+    expect(screen.getByText("내용")).toHaveClass("d_inline-flex");
+  });
+});
+
+describe("wrap 속성", () => {
+  test.each([
+    { wrap: "nowrap", className: "flex-wrap_nowrap" },
+    { wrap: "wrap", className: "flex-wrap_wrap" },
+    { wrap: "wrapReverse", className: "flex-wrap_wrap-reverse" },
+  ] as const)("wrap=$wrap일 때 $className 클래스가 적용됨", ({
+    wrap,
+    className,
+  }) => {
+    render(<HStack wrap={wrap}>내용</HStack>);
+
+    expect(screen.getByText("내용")).toHaveClass(className);
+  });
+});
+
+describe("align 속성", () => {
+  test.each([
+    { align: "start", className: "ai_flex-start" },
+    { align: "center", className: "ai_center" },
+    { align: "end", className: "ai_flex-end" },
+    { align: "stretch", className: "ai_stretch" },
+    { align: "baseline", className: "ai_baseline" },
+  ] as const)("align=$align일 때 $className 클래스가 적용됨", ({
+    align,
+    className,
+  }) => {
+    render(<HStack align={align}>내용</HStack>);
+
+    expect(screen.getByText("내용")).toHaveClass(className);
+  });
+});
+
+describe("justify 속성", () => {
+  test.each([
+    { justify: "start", className: "jc_flex-start" },
+    { justify: "center", className: "jc_center" },
+    { justify: "end", className: "jc_flex-end" },
+    { justify: "between", className: "jc_space-between" },
+    { justify: "around", className: "jc_space-around" },
+    { justify: "evenly", className: "jc_space-evenly" },
+  ] as const)("justify=$justify일 때 $className 클래스가 적용됨", ({
+    justify,
+    className,
+  }) => {
+    render(<HStack justify={justify}>내용</HStack>);
+
+    expect(screen.getByText("내용")).toHaveClass(className);
+  });
+});
+
+describe("gap 속성", () => {
+  test("gap이 지정되면 gap 스타일이 적용됨", () => {
+    render(<HStack gap={8}>내용</HStack>);
+
+    expect(screen.getByText("내용")).toHaveClass("gap_8");
+  });
+});
+
+describe("className 속성", () => {
+  test("외부 className이 병합되어 적용됨", () => {
+    render(<HStack className="custom-class">내용</HStack>);
+
+    const element = screen.getByText("내용");
+    expect(element).toHaveClass("custom-class");
+    expect(element).toHaveClass("d_flex");
+    expect(element).toHaveClass("flex-d_row");
+  });
+});

--- a/src/components/HStack/HStack.tsx
+++ b/src/components/HStack/HStack.tsx
@@ -1,0 +1,14 @@
+import type { ReactNode } from "react";
+import { Flex, type FlexProps } from "../Flex/Flex";
+
+export interface HStackProps extends Omit<FlexProps, "direction"> {
+  children: ReactNode;
+}
+
+export const HStack = ({ children, ...props }: HStackProps) => {
+  return (
+    <Flex direction="row" {...props}>
+      {children}
+    </Flex>
+  );
+};

--- a/src/components/Icon/Icon.test.tsx
+++ b/src/components/Icon/Icon.test.tsx
@@ -1,31 +1,30 @@
-import { composeStories } from '@storybook/react-vite';
-import { render, screen } from '@testing-library/react';
-import { expect, test } from 'vitest';
-import { type IconName, icons } from '../../tokens/iconography';
-import * as stories from './Icon.stories';
+import { composeStories } from "@storybook/react-vite";
+import { render, screen } from "@testing-library/react";
+import { expect, test } from "vitest";
+import { type IconName, icons } from "../../tokens/iconography";
+import * as stories from "./Icon.stories";
 
 const { Basic } = composeStories(stories);
 
-test.each(Object.keys(icons) as IconName[])(
-  '아이콘 "%s"가 기본 설정으로 정상 표시된다',
-  (name) => {
-    render(<Basic name={name} aria-label={name} />);
+test.each(
+  Object.keys(icons) as IconName[],
+)('아이콘 "%s"가 기본 설정으로 정상 표시된다', (name) => {
+  render(<Basic name={name} aria-label={name} />);
 
-    expect(screen.getByLabelText(name)).toBeInTheDocument();
-    expect(screen.getByLabelText(name)).toHaveClass('c_currentcolor');
-    expect(screen.getByLabelText(name)).toHaveClass('w_1.25rem h_1.25rem');
-    expect(screen.getByLabelText(name)).toHaveAttribute('aria-label', name);
-    expect(screen.getByLabelText(name)).toHaveAttribute('role', 'img');
-  }
-);
+  expect(screen.getByLabelText(name)).toBeInTheDocument();
+  expect(screen.getByLabelText(name)).toHaveClass("c_currentcolor");
+  expect(screen.getByLabelText(name)).toHaveClass("w_1.25rem h_1.25rem");
+  expect(screen.getByLabelText(name)).toHaveAttribute("aria-label", name);
+  expect(screen.getByLabelText(name)).toHaveAttribute("role", "img");
+});
 
 test.each([
-  ['neutral', 'c_fg.neutral'],
-  ['brand', 'c_fg.brand'],
-  ['danger', 'c_fg.danger'],
-  ['warning', 'c_fg.warning'],
-  ['success', 'c_fg.success'],
-  ['info', 'c_fg.info'],
+  ["neutral", "c_fg.neutral"],
+  ["brand", "c_fg.brand"],
+  ["danger", "c_fg.danger"],
+  ["warning", "c_fg.warning"],
+  ["success", "c_fg.success"],
+  ["info", "c_fg.info"],
 ] as const)('tone="%s"일 때 해당 색상(%s)이 적용된다', (tone, className) => {
   render(<Basic tone={tone} aria-label={tone} />);
 
@@ -33,20 +32,20 @@ test.each([
 });
 
 test.each([
-  ['xs', 'w_0.75rem h_0.75rem'],
-  ['sm', 'w_1rem h_1rem'],
-  ['md', 'w_1.25rem h_1.25rem'],
-  ['lg', 'w_1.5rem h_1.5rem'],
+  ["xs", "w_0.75rem h_0.75rem"],
+  ["sm", "w_1rem h_1rem"],
+  ["md", "w_1.25rem h_1.25rem"],
+  ["lg", "w_1.5rem h_1.5rem"],
 ] as const)('size="%s"일 때 해당 크기(%s)로 렌더링된다', (size, className) => {
   render(<Basic size={size} aria-label={size} />);
 
   expect(screen.getByLabelText(size)).toHaveClass(className);
 });
 
-test('등록되지 않은 아이콘 이름을 전달하면 물음표 아이콘으로 대체된다', () => {
-  render(<Basic name={'nonExistent' as IconName} aria-label='fallback' />);
+test("등록되지 않은 아이콘 이름을 전달하면 물음표 아이콘으로 대체된다", () => {
+  render(<Basic name={"nonExistent" as IconName} aria-label="fallback" />);
 
-  const icon = screen.getByLabelText('fallback');
+  const icon = screen.getByLabelText("fallback");
   expect(icon).toBeInTheDocument();
-  expect(icon).toHaveAttribute('role', 'img');
+  expect(icon).toHaveAttribute("role", "img");
 });


### PR DESCRIPTION
## 개요
Flex 컴포넌트를 기반으로 HStack (Horizontal Stack) 컴포넌트를 구현했습니다.

## 변경 사항
- `src/components/HStack/HStack.tsx`: Flex 래핑, `direction="row"` 고정
- `src/components/HStack/HStack.stories.tsx`: Basic, Justify, Align, Gap, Wrap, Inline 스토리
- `src/components/HStack/HStack.test.tsx`: 29개 테스트
- 코드 포맷팅 적용 (`.storybook/main.ts`, `Icon.test.tsx`)

## 설계 결정
- VStack과 동일한 패턴으로 Flex의 단순 래퍼로 구현
- `direction` prop만 제외하고 나머지 FlexProps 모두 지원

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added HStack component for horizontal layout compositions with flexible justification, alignment, wrapping, and gap customization options.

* **Tests**
  * Added comprehensive test coverage for HStack component behavior and prop variations.

* **Chores**
  * Updated code formatting for consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->